### PR TITLE
Prevent HTTP 429 error Too Many Requests

### DIFF
--- a/slack_history.py
+++ b/slack_history.py
@@ -55,7 +55,8 @@ def getHistory(pageableObject, channelId, pageSize = 100):
 				count	 = pageSize
 			).body
 		except:
-			time.sleep(5)
+			time.sleep(1)
+			continue
 			
 		messages.extend(response['messages'])
 

--- a/slack_history.py
+++ b/slack_history.py
@@ -4,6 +4,7 @@ import argparse
 import os
 import shutil
 import copy
+import time
 from datetime import datetime
 
 # This script finds all channels, private channels and direct messages
@@ -46,13 +47,16 @@ def getHistory(pageableObject, channelId, pageSize = 100):
 	lastTimestamp = None
 
 	while(True):
-		response = pageableObject.history(
-			channel = channelId,
-			latest	= lastTimestamp,
-			oldest	= 0,
-			count	 = pageSize
-		).body
-
+		try:
+			response = pageableObject.history(
+				channel = channelId,
+				latest	= lastTimestamp,
+				oldest	= 0,
+				count	 = pageSize
+			).body
+		except:
+			time.sleep(5)
+			
 		messages.extend(response['messages'])
 
 		if (response['has_more'] == True):


### PR DESCRIPTION
Prevent the HTTPError: 429 Client Error: Too Many Requests for url